### PR TITLE
Fix crashes on SymRobot on for QT_VERSION > 6.6.0

### DIFF
--- a/Src/SimRobot/MainWindow.cpp
+++ b/Src/SimRobot/MainWindow.cpp
@@ -939,12 +939,14 @@ void MainWindow::setGuiUpdateRate(int rate)
 
 void MainWindow::open()
 {
-  QString fileName = QFileDialog::getOpenFileName(this,
-    tr("Open File"), settings.value("OpenDirectory", "").toString(), tr("Robot Simulation Files (*.ros2 *.ros2d)")
-#ifdef LINUX
-                                                  , nullptr, QFileDialog::DontUseNativeDialog
-#endif
-                                                  );
+  QString fileName = QFileDialog::getOpenFileName(
+      this, tr("Open File"), settings.value("OpenDirectory", "").toString(),
+      tr("Robot Simulation Files (*.ros2 *.ros2d)")
+  #if defined LINUX  && defined(QT_VERSION) && (QT_VERSION <= QT_VERSION_CHECK(6, 6, 0))
+            ,
+        nullptr, QFileDialog::DontUseNativeDialog
+  #endif
+  );
 
   if(fileName.isEmpty())
     return;

--- a/Src/SimRobot/RegisteredDockWidget.cpp
+++ b/Src/SimRobot/RegisteredDockWidget.cpp
@@ -194,9 +194,10 @@ void RegisteredDockWidget::exportAsSvg()
   QSettings& settings = MainWindow::application->getSettings();
   QString fileName = QFileDialog::getSaveFileName(this,
     tr("Export as SVG"), settings.value("ExportDirectory", "").toString(), tr("Scalable Vector Graphics (*.svg)")
-#ifdef LINUX
-    , nullptr, QFileDialog::DontUseNativeDialog
-#endif
+  #if defined LINUX  && defined(QT_VERSION) && (QT_VERSION <= QT_VERSION_CHECK(6, 6, 0))
+  ,
+  nullptr, QFileDialog::DontUseNativeDialog
+  #endif
     );
   if(fileName.isEmpty())
     return;
@@ -224,9 +225,11 @@ void RegisteredDockWidget::exportAsPng()
   QSettings& settings = MainWindow::application->getSettings();
   QString fileName = QFileDialog::getSaveFileName(this,
     tr("Export as PNG"), settings.value("ExportDirectory", "").toString(), tr("(*.png)")
-#ifdef LINUX
-    , nullptr, QFileDialog::DontUseNativeDialog
-#endif
+  #if defined LINUX  && defined(QT_VERSION) && (QT_VERSION <= QT_VERSION_CHECK(6, 6, 0))
+  ,
+  nullptr, QFileDialog::DontUseNativeDialog
+  #endif
+
     );
   if(fileName.isEmpty())
     return;

--- a/Src/SimRobotCore2/SimObjectWidget.cpp
+++ b/Src/SimRobotCore2/SimObjectWidget.cpp
@@ -558,9 +558,10 @@ void SimObjectWidget::exportAsImage(int width, int height)
   QSettings& settings = CoreModule::application->getSettings();
   QString fileName = QFileDialog::getSaveFileName(this,
                                                   tr("Export as Image"), settings.value("ExportDirectory", "").toString(), tr("Portable Network Graphic (*.png)")
-#ifdef LINUX
-                                                  , nullptr, QFileDialog::DontUseNativeDialog
-#endif
+  #if defined LINUX  && defined(QT_VERSION) && (QT_VERSION <= QT_VERSION_CHECK(6, 6, 0))
+  ,
+  nullptr, QFileDialog::DontUseNativeDialog
+  #endif
                                                   );
   if(fileName.isEmpty())
     return;


### PR DESCRIPTION
Only call `QFileDialog::DontUseNativeDialog` if QT_VERSION is less than 6.0.0

Fixes a crash that occured, when selecting a scene. (File Picker did not launch)

 Before merging this pull request, it would be appreciated if someone using Ubuntu 24.04 or earlier could verify if the SimRobot still functions as expected with GTK3 and Qt5, as described in this workaround:

[Workaround for QEventLoop compatibility](https://github.com/bhuman/SimRobot/commit/9573323155840c7dde5a5e71733c9adf2ab6ed0d)